### PR TITLE
Fix account saving database query

### DIFF
--- a/battlegrounds/class/sDatabase.lua
+++ b/battlegrounds/class/sDatabase.lua
@@ -80,8 +80,8 @@ function Database.saveAccount(ip, serial, data)
 		`coinsSpent`=?
 	WHERE `serial`=?;]],
 		ip,
-		data.gamesPlayed,
 		data.language,
+		data.gamesPlayed,
 		data.wins,
 		data.losses,
 		data.deaths,


### PR DESCRIPTION
Fixes the following error:
WARNING: [mtabg]/battlegrounds/class/sDatabase.lua:69: dbExec failed; (1366) Incorrect integer value: 'en' for column `mtabg`.`accounts`.`gamesPlayed` at row 1 